### PR TITLE
Dump tweets to JSON in separate files.

### DIFF
--- a/example.json
+++ b/example.json
@@ -5,11 +5,17 @@
     "links" : {
       "url" : "http://example.com",
       "title" : "Example"
-    }
+    },
+    "location" : [
+      -119.859391, 33.013882
+    ]
   },
   {
     "user" : "twitter_user",
     "text" : "Hello world!",
-    "links" : {}
+    "links" : {},
+    "location" : [
+      -115.904313, 34.884276
+    ]
   }
 ]

--- a/example.json
+++ b/example.json
@@ -1,0 +1,15 @@
+[
+  {
+    "user" : "john_smith",
+    "text" : "the quick brown fox jumps over the lazy dog",
+    "links" : {
+      "url" : "http://example.com",
+      "title" : "Example"
+    }
+  },
+  {
+    "user" : "twitter_user",
+    "text" : "Hello world!",
+    "links" : {}
+  }
+]


### PR DESCRIPTION
This PR implements JSON serialization and proper file splitting of data.  The JSON is serialized according to the format shown in `example.json`, with minimal whitespace.  

Furthermore, the twitter API now streams asynchronously, allowing us to use extra code in the main loop.  As an example, the code currently saves the data every 10 or so seconds.  

The parameters are at the top of `creatingfiles.py`:
* `max_file_size` : Desired file size in bytes.  (actual file size can be somewhat more than this)
* `avg_tweet_size`: Average number of bytes a tweet entry in the JSON contains.  Set this empirically.
* `dump_interval_secs`: Number of seconds to wait before saving to JSON file.'

TODO:
* ~~`tweet_data` is not thread-safe.~~ d0ad034
* Add geolocation data to tweets.
* Crawl links in tweet body.

LOW PRIORITY:
* Separate tweet entries by line.